### PR TITLE
Weekly update that fixes issue #48 and #49.

### DIFF
--- a/data.json
+++ b/data.json
@@ -2,7 +2,7 @@
   "meta": {
     "siteName": "PitchMap PNW",
     "tagline": "The PNW startup pitch competition directory",
-    "lastUpdated": "2026-04-10",
+    "lastUpdated": "2026-04-15",
     "maintainer": "Leila Kaneda",
     "githubHandle": "lkaneda"
   },
@@ -28,9 +28,10 @@
           "status": "accepting",
           "description": "Portland's monthly pitch event reintroduced in 2024 by UpStart Collective. Founders get 3 minutes to pitch, audience votes for the winner. Monthly champion advances to an annual Championship Showdown.",
           "url": "https://www.pitchatdemolicious.com",
-          "eventUrl": "https://forms.gle/pqoyNY9q11CMse8t6",
+          "eventUrl": "https://forms.gle/TKvxFS2taT7NtRZb8",
           "notes": "Actively accepting pitch applications for 2026. Sign up at their website.",
-          "prizeType": "cash"
+          "prizeType": "cash",
+          "internalTags": ["updated"]
         }
       ]
     },
@@ -126,10 +127,7 @@
           "eventUrl": null,
           "notes": "2026 Pitch Day completed April 7. Investment decision announced August 2026.",
           "prizeType": "investment",
-          "accelerator": true,
-          "internalTags": [
-            "updated"
-          ]
+          "accelerator": true
         },
         {
           "name": "Angel Oregon CPG",
@@ -139,10 +137,7 @@
           "eventUrl": null,
           "notes": "2026 Pitch Day completed April 8. Investment decision announced June 2026.",
           "prizeType": "investment",
-          "accelerator": true,
-          "internalTags": [
-            "updated"
-          ]
+          "accelerator": true
         },
         {
           "name": "Angel Oregon BIO",
@@ -152,10 +147,7 @@
           "eventUrl": null,
           "notes": "2026 Pitch Day completed April 9. Investment decision announced December 2026.",
           "prizeType": "investment",
-          "accelerator": true,
-          "internalTags": [
-            "updated"
-          ]
+          "accelerator": true
         },
         {
           "name": "Pop Up & Pitch",
@@ -274,10 +266,7 @@
           "eventUrl": null,
           "notes": "Applications for the 2026 cohort are now closed. Program runs May\u2013September.",
           "prizeType": "investment",
-          "accelerator": true,
-          "internalTags": [
-            "updated"
-          ]
+          "accelerator": true
         }
       ]
     },
@@ -359,10 +348,7 @@
           "url": "https://www.founderslive.com/",
           "eventUrl": null,
           "notes": "April 9, 2026 event completed. No next Portland date announced \u2014 monitor their events page.",
-          "prizeType": "in-kind",
-          "internalTags": [
-            "updated"
-          ]
+          "prizeType": "in-kind"
         }
       ]
     },
@@ -389,10 +375,7 @@
           "url": "https://www.founderslive.com/events-list/seattle-2026-05",
           "eventUrl": "https://www.founderslive.com/pitch",
           "notes": "Next event May 28, 2026. Check their events page for registration.",
-          "prizeType": "in-kind",
-          "internalTags": [
-            "updated"
-          ]
+          "prizeType": "in-kind"
         }
       ]
     },
@@ -432,7 +415,7 @@
     {
       "id": "oregon-startup-center",
       "org": "Oregon Startup Center",
-      "url": "https://www.oregonstartupcenter.org/beaverton-startup-challenge-applications-open",
+      "url": "https://www.oregonstartupcenter.org/",
       "serviceArea": "portland-metro",
       "location": {
         "lat": 45.4871,
@@ -449,7 +432,7 @@
           "name": "Beaverton Startup Challenge",
           "status": "scheduled",
           "description": "Annual funding competition operated by the Oregon Startup Center in partnership with the City of Beaverton and the Westside Startup Fund. Open to scalable startups across tech, consumer products, manufacturing, bio/life sciences, and cleantech. Winners receive a SAFE note investment (historically ~$20k), 6 months of mentorship, and a Demo Day showcase.",
-          "url": "https://www.oregonstartupcenter.org/beaverton-startup-challenge-applications-open",
+          "url": "https://www.oregonstartupcenter.org/beaverton-startup-challenge",
           "eventUrl": null,
           "notes": "Applications closed March 27, 2026. Event/Demo Day upcoming \u2014 check their site for date.",
           "prizeType": "investment",
@@ -562,10 +545,7 @@
           "url": "https://foster.uw.edu/centers/buerk-ctr-entrepreneurship/entrepreneurship-competitions/dempsey-startup-competition/",
           "eventUrl": "https://apply.younoodle.com/showcase/competition/2026_dempsey_startup_competition",
           "notes": "Applications closed April 6, 2026. Competition rounds ongoing through May 21, 2026. Open to Oregon students.",
-          "prizeType": "cash",
-          "internalTags": [
-            "updated"
-          ]
+          "prizeType": "cash"
         }
       ]
     },
@@ -593,10 +573,7 @@
           "eventUrl": null,
           "notes": "2026 competition concluded. Winners announced April 2, 2026. Monitor for next cycle.",
           "prizeType": "loan",
-          "serves": "Washington, Alaska & Northern Idaho",
-          "internalTags": [
-            "updated"
-          ]
+          "serves": "Washington, Alaska & Northern Idaho"
         },
         {
           "name": "SCORE Tech Entrepreneurs Pitch Contest",
@@ -633,8 +610,9 @@
           "url": "https://www.techoregon.org/",
           "eventUrl": "https://web.cvent.com/event/df647f26-4b9b-45d9-ad8f-07b1126ee6b3/summary",
           "notes": "April 22, 2026 in Portland. Open to pre-seed and seed-stage AI startups with PNW roots.",
-          "prizeType": "none",
-          "serves": "Oregon & Washington"
+          "prizeType": "in-kind",
+          "serves": "Oregon & Washington",
+          "internalTags": ["updated"]
         }
       ]
     },
@@ -661,10 +639,40 @@
           "url": "https://www.startupworldcup.io/portland-oregon",
           "eventUrl": "https://form.123formbuilder.com/6925524/usa-portland-startup-world-cup-application",
           "notes": "May 13\u201314, 2026 at Upstart Collective, 111 SW 5th Ave, Portland. Applications open through May 8. Co-hosted alongside Portland Startup Week.",
-          "prizeType": "investment",
-          "internalTags": [
-            "new"
-          ]
+          "prizeType": "investment"
+        }
+      ]
+    },
+    {
+      "id": "south-coast-development-council",
+      "org": "South Coast Development Council",
+      "url": "https://scdcinc.org/",
+      "serviceArea": "oregon-south-coast",
+      "location": {
+        "lat": 43.3665,
+        "lng": -124.2179,
+        "city": "Coos Bay, OR"
+      },
+      "tags": [
+        "general",
+        "regional",
+        "annual"
+      ],
+      "events": [
+        {
+          "name": "Pitch Night: Curry County",
+          "status": "accepting",
+          "description": "Annual pitch competition hosted by the South Coast Development Council serving entrepreneurs in Coos, Curry, and Douglas Counties. Focuses on priority sectors including outdoor recreation, digital services, advanced manufacturing, value-added agriculture, clean energy, marine/coastal industries, and forestry innovation.",
+          "url": "https://scdcinc.org/entrepreneurship/pitch-night/",
+          "eventUrl": null,
+          "notes": "Applications due April 29, 2026 at 8:00 AM. Open to entrepreneurs and startups in the Innovation Hub's priority sectors.",
+          "prizeType": "both",
+          "counties": [
+            "Coos County",
+            "Curry County",
+            "Douglas County"
+          ],
+          "internalTags": ["new"]
         }
       ]
     }

--- a/index.html
+++ b/index.html
@@ -1116,6 +1116,7 @@
     <button class="pill" data-filter="portland-metro">📍 Portland Metro</button>
     <button class="pill" data-filter="seattle-metro">📍 Seattle Metro</button>
     <button class="pill" data-filter="gorge">🌊 Gorge</button>
+    <button class="pill" data-filter="oregon-south-coast">🌊 South Coast</button>
     <button class="pill" data-filter="cleantech">♻️ Cleantech</button>
     <button class="pill" data-filter="university">🎓 University</button>
     <button class="pill" data-filter="cash">💵 Cash / Grant</button>
@@ -1270,6 +1271,7 @@
       'pnw':            ['area-pnw',      '🏔️ PNW'],
       'washington':     ['area-pnw',      '🏔️ Washington'],
       'gorge':          ['area-oregon',   '🌊 Columbia River Gorge'],
+      'oregon-south-coast': ['area-oregon', '🌊 Oregon South Coast'],
     };
     const [cls, label] = map[area] || ['', area];
     return `<span class="area-badge ${cls}">${label}</span>`;
@@ -1330,6 +1332,7 @@
       if (f === 'portland-metro') return c.serviceArea === 'portland-metro';
       if (f === 'seattle-metro')  return c.serviceArea === 'seattle-metro';
       if (f === 'gorge')          return c.serviceArea === 'gorge';
+      if (f === 'oregon-south-coast') return c.serviceArea === 'oregon-south-coast';
       if (f === 'accepting' || f === 'scheduled' || f === 'monitor' || f === 'inactive') return best === f;
       if (f === 'cash')       return c.events.some(e => e.prizeType === 'cash' || e.prizeType === 'both');
       if (f === 'investment') return c.events.some(e => e.prizeType === 'investment' || e.prizeType === 'both');
@@ -1359,6 +1362,7 @@
         'washington':          'washington',
         'pnw':                 'pacific northwest oregon washington pnw',
         'gorge':               'gorge columbia river gorge oregon washington',
+        'oregon-south-coast':  'oregon south coast coos curry douglas lane florence reedsport coos bay brookings',
       }[c.serviceArea] || c.serviceArea;
 
       const matchesSearch =
@@ -1611,12 +1615,13 @@
         const state = address.state || '';
         const stateCode = state.includes('Washington') ? 'WA' : state.includes('Oregon') ? 'OR' : null;
         const userCounty = address.county || '';
+        const userCity = address.city || address.town || address.village || address.hamlet || '';
         if (userMarker) map.removeLayer(userMarker);
         userMarker = L.circleMarker([parseFloat(lat), parseFloat(lon)], {
           radius: 8, fillColor: '#fff', color: '#f0a500', weight: 3, fillOpacity: 1
         }).addTo(map).bindPopup(`📍 ${query}`).openPopup();
         map.setView([parseFloat(lat), parseFloat(lon)], 10);
-        showNearbyResults(parseFloat(lat), parseFloat(lon), query, stateCode, userCounty);
+        showNearbyResults(parseFloat(lat), parseFloat(lon), query, stateCode, userCounty, userCity);
       } else {
         alert(`Couldn't find "${query}" — try a city name or ZIP code.`);
       }
@@ -1652,7 +1657,7 @@
     return { inOR, inWA };
   }
 
-  function servesLocation(comp, userLat, userLng, userState, userCounty) {
+  function servesLocation(comp, userLat, userLng, userState, userCounty, userCity = '') {
     if (!comp.location) return false;
     const distToComp = haversineDistance(userLat, userLng, comp.location.lat, comp.location.lng);
     let inOR, inWA;
@@ -1677,13 +1682,13 @@
         return e.counties.some(c => userCounty.toLowerCase().includes(c.toLowerCase().replace(' county', '')) ||
                                     c.toLowerCase().includes(userCounty.toLowerCase().replace(' county', '')));
       }
-      return eventMatchesArea(comp, distToComp, inOR, inWA, inPNW);
+      return eventMatchesArea(comp, distToComp, inOR, inWA, inPNW, userCity);
     });
 
     return hasAnyMatchingEvent;
   }
 
-  function eventMatchesArea(comp, distToComp, inOR, inWA, inPNW) {
+  function eventMatchesArea(comp, distToComp, inOR, inWA, inPNW, userCity = '') {
     if (comp.serviceArea === 'pnw')                 return inPNW;
     if (comp.serviceArea === 'oregon')              return inOR;
     if (comp.serviceArea === 'oregon-sw-washington') return inOR || (inWA && distToComp <= 150);
@@ -1691,16 +1696,21 @@
     if (comp.serviceArea === 'portland-metro')      return distToComp <= 50;
     if (comp.serviceArea === 'seattle-metro')       return distToComp <= 50;
     if (comp.serviceArea === 'gorge')               return distToComp <= 60;
+    if (comp.serviceArea === 'oregon-south-coast') {
+      const southCoastCities = ['florence','reedsport','north bend','coos bay','bandon','coquille','lakeside','myrtle point','powers','port orford','gold beach','brookings'];
+      const city = userCity.toLowerCase();
+      return inOR && southCoastCities.some(c => city.includes(c) || c.includes(city) && city.length > 3);
+    }
     return false;
   }
 
-  function showNearbyResults(userLat, userLng, locationName, userState, userCounty) {
+  function showNearbyResults(userLat, userLng, locationName, userState, userCounty, userCity = '') {
     const list = document.getElementById('nearby-list');
     const label = document.getElementById('nearby-label');
     const wrapper = document.getElementById('nearby-results');
 
     const matched = DATA.competitions
-      .filter(c => servesLocation(c, userLat, userLng, userState, userCounty))
+      .filter(c => servesLocation(c, userLat, userLng, userState, userCounty, userCity))
       .map(c => ({
         ...c,
         distance: c.location ? haversineDistance(userLat, userLng, c.location.lat, c.location.lng) : 9999


### PR DESCRIPTION
⏺ === Weekly Update Summary (2026-04-15) ===                                                                                                                                                                             
                                                                                                                                                                                                                         
  CLEARED INTERNAL TAGS: 8 events had tags removed                                                                                                                                                                       
    (Angel Oregon Technology, Angel Oregon CPG, Angel Oregon BIO, 45Camp Accelerator,                                                                                                                                    
     Founders Live Build — Portland, Founders Live Seattle, Dempsey Startup Competition,                                                                                                                                 
     SCORE Washington Women's Pitch Contest, Startup World Cup Portland Regional)                                                                                                                                        
                                                                                                                                                                                                                         
  UPDATED LISTINGS (3):                                                                                                                                                                                                  
    - Demolicious / UpStart Collective: eventUrl updated to new sign-up form URL                                                                                                                                         
    - Oregon Startup Center (Beaverton Startup Challenge): competition url fixed (old URL was 404); event url updated to /beaverton-startup-challenge                                                                    
    - Technology Association of Oregon (TAO) [issue #48]: prizeType changed from "none" to "in-kind" (status was already "scheduled")                                                                                    
                                                                                                                                                                                                                         
  NEW ENTRIES ADDED (1):                                                                                                                                                                                                 
    - South Coast Development Council — Pitch Night: Curry County [issue #49]                                                                                                                                            
      Accepting applications through April 29, 2026; serves Coos, Curry & Douglas Counties                                                                                                                               
                                                                                                                                                                                                                         
  NO CHANGES DETECTED:                                                                                                                                                                                                   
    14 listings checked, no other material changes found.                