### PR TITLE
Weekly update. Two events happenign today and have their statuses cha…

### DIFF
--- a/data.json
+++ b/data.json
@@ -2,7 +2,7 @@
   "meta": {
     "siteName": "PitchMap PNW",
     "tagline": "The PNW startup pitch competition directory",
-    "lastUpdated": "2026-05-06",
+    "lastUpdated": "2026-05-13",
     "maintainer": "Leila Kaneda",
     "githubHandle": "lkaneda"
   },
@@ -135,12 +135,13 @@
         },
         {
           "name": "Angel Oregon CPG",
-          "status": "monitor",
-          "description": "5-week intensive program for early-stage consumer packaged goods founders culminating in a live Pitch Day in front of active investors. Investment announced in June 2026.",
+          "status": "accepting",
+          "description": "5-week capital and funding literacy program for early-stage consumer packaged goods founders (food, beverage, personal care, wellness, lifestyle, and pet products) in Oregon and SW Washington. Virtual curriculum covers funding strategies, valuations, cap tables, and due diligence, culminating in a live Pitch Day in front of investors and community partners.",
           "url": "https://www.oen.org/2026-angel-oregon-consumer-packaged-goods/",
-          "eventUrl": null,
-          "notes": "2026 Pitch Day completed April 8. Investment decision announced June 2026.",
+          "eventUrl": "https://oen.app.neoncrm.com/np/clients/oen/event.jsp?event=520&",
+          "notes": "Cohort 1 Pitch Day completed April 8. Cohort 2 now accepting registrations: September 16 – October 21, 2026. Pitch Day is October 21. $150 OEN members / $200 non-members.",
           "prizeType": "investment",
+          "internalTags": ["updated"],
           "accelerator": true
         },
         {
@@ -379,8 +380,7 @@
           "url": "https://www.founderslive.com/events-list/seattle-2026-05",
           "eventUrl": "https://www.founderslive.com/pitch",
           "notes": "Next event May 28, 2026 at Seattle Climate Innovation Hub, 1215 4th Ave, Seattle.",
-          "prizeType": "in-kind",
-          "internalTags": ["updated"]
+          "prizeType": "in-kind"
         }
       ]
     },
@@ -435,12 +435,13 @@
       "events": [
         {
           "name": "Beaverton Startup Challenge",
-          "status": "scheduled",
+          "status": "monitor",
           "description": "Annual funding competition operated by the Oregon Startup Center in partnership with the City of Beaverton and the Westside Startup Fund. Open to scalable startups across tech, consumer products, manufacturing, bio/life sciences, and cleantech. Winners receive a SAFE note investment (historically ~$20k), 6 months of mentorship, and a Demo Day showcase.",
           "url": "https://www.oregonstartupcenter.org/beaverton-startup-challenge",
-          "eventUrl": "https://eventship.com/event/beaverton-startup-challenge-demo-day",
-          "notes": "Applications closed March 27, 2026. Event/Demo Day on May 13 at the Patricia Reser Center for the Arts. Registration open.",
+          "eventUrl": null,
+          "notes": "2026 Demo Day completed May 13 at the Patricia Reser Center for the Arts. Monitor for 2027 cycle — applications typically open Q1.",
           "prizeType": "investment",
+          "internalTags": ["updated"],
           "counties": [
             "Washington County"
           ]
@@ -638,12 +639,13 @@
       "events": [
         {
           "name": "Startup World Cup Portland Regional",
-          "status": "accepting",
+          "status": "scheduled",
           "description": "Inaugural Portland regional of the global Startup World Cup, organized in partnership with Oregon Entrepreneurs Network, Upstart Collective, and Business Oregon's Oregon Innovation Showcase. Ten finalist startups each give a 4-minute pitch and 2-minute Q&A before an investor panel. The regional winner advances to the global finale competing for $1,000,000.",
           "url": "https://www.startupworldcup.io/portland-oregon",
-          "eventUrl": "https://form.123formbuilder.com/6925524/usa-portland-startup-world-cup-application",
-          "notes": "May 13–14, 2026 at Upstart Collective, 111 SW 5th Ave, Portland. Applications open through May 8. Co-hosted alongside Portland Startup Week.",
-          "prizeType": "investment"
+          "eventUrl": null,
+          "notes": "2026 event completed May 13–14 at Upstart Collective, 111 SW 5th Ave, Portland. Monitor for 2027 cycle.",
+          "prizeType": "investment",
+          "internalTags": ["updated"]
         }
       ]
     },
@@ -671,7 +673,6 @@
           "eventUrl": null,
           "notes": "Applications closed April 29, 2026. Event date: June 12, 2026, 5–8 PM at Mr. Ed's, Port Orford.",
           "prizeType": "cash",
-          "internalTags": ["updated"],
           "counties": [
             "Coos County",
             "Curry County",


### PR DESCRIPTION
 === Weekly Update Summary (2026-05-13) ===
                                                                                                                                                                                                                                                       
  CLEARED INTERNAL TAGS: 2 competitions had tags removed                                                                                                                                                                                               
    (founders-live-seattle, south-coast-development-council)                                                                                                                                                                                           
                                                                                                                                                                                                                                                     
  UPDATED LISTINGS (4):                                                                                                                                                                                                                                
    - Angel Oregon CPG (OEN): Status monitor → accepting. Cohort 2 now open                                                                                                                                                                            
      for registration (Sep 16 – Oct 21, 2026, Pitch Day Oct 21). EventUrl                                                                                                                                                                             
      updated. Notes corrected: investment announcement is June 2027, not 2026.                                                                                                                                                                        
      Description updated to reflect "capital and funding literacy program."                                                                                                                                                                           
    - Beaverton Startup Challenge: Status scheduled → monitor. Demo Day held                                                                                                                                                                           
      today (May 13) at Patricia Reser Center for the Arts. EventUrl → null.                                                                                                                                                                           
    - Startup World Cup Portland Regional: Status accepting → scheduled.                                                                                                                                                                               
      Applications closed May 8; event underway May 13–14. EventUrl → null.                                                                                                                                                                            
      Notes updated.                                                                                                                                                                                                                                   
    - (No changes to the above required re-check next week to flip to monitor.)                                                                                                                                                                        
                                                                                                                                                                                                                                                       
  NO CHANGES DETECTED:                                                                                                                                                                                                                                 
    17 listings checked, no material changes found.                                                                                                                                                                                                    
    (demolicious, tie-oregon ×4, oen pitch-please/tech/bio, psu,                                                                                                                                                                                       
    invent-oregon, obi, vertuelab, cascadia-cleantech, portland-startup-week,                                                                                                                                                                          
    founders-live-portland, founders-live-seattle, gorge-pitchfest,                                                                                                                                                                                    
    business-impact-nw, dempsey, score-washington, tao, south-coast-dev-council)                                                                                                                                                                       
                                                                                                                                                                                                                                                       
  NEW ENTRIES ADDED: None                    