### PR TITLE
Weekly update. Correct mistake from last week with beav startup challenge

### DIFF
--- a/data.json
+++ b/data.json
@@ -2,7 +2,7 @@
   "meta": {
     "siteName": "PitchMap PNW",
     "tagline": "The PNW startup pitch competition directory",
-    "lastUpdated": "2026-07-01",
+    "lastUpdated": "2026-07-08",
     "maintainer": "Leila Kaneda",
     "githubHandle": "lkaneda"
   },
@@ -70,8 +70,7 @@
           "url": "https://www.tieoregon.org/pitch-club",
           "eventUrl": "https://events.tie.org/events?brandId=34204000007365481&isEmbed=true",
           "notes": "Ongoing monthly program. Requires TiE Oregon membership. Contact Kari.Naone@oregon.tie.org or register through the TiE Oregon events page.",
-          "prizeType": "none",
-          "internalTags": ["updated"]
+          "prizeType": "none"
         },
         {
           "name": "TiE Women Global Pitch Competition",
@@ -79,7 +78,7 @@
           "description": "Global pitch competition dedicated to empowering women entrepreneurs. The PNW regional winner advances to compete globally for equity-free prize money. Open to female-founded or co-founded businesses (minimum 33% female equity) registered after January 1, 2019 and actively seeking funding.",
           "url": "https://www.tiewomen.org/",
           "eventUrl": "https://tiewomen.pitchday.pro/events-portfolio/1710",
-          "notes": "Application deadline was June 30, 2026 (now closed). Regional Finals June 16–Aug 15; Semi-finals Sept 24–Oct 7; Grand Finale December 2026. Over $100,000 in equity-free prizes; top winner receives $50,000.",
+          "notes": "Application deadline was June 30, 2026 (now closed). Chapter Mentoring & Finals: June 26–Aug 31; Semi-finals NA/Europe: September 17–18 (TiE Los Angeles); Semi-finals Asia: September 24–26 (TiE Hyderabad); Grand Finale: December 14–15, 2026 at TiE Global Summit in Indore, India. Over $100,000 in equity-free prizes; top winner receives $50,000.",
           "prizeType": "cash",
           "serves": "Pacific Northwest (with global competition)",
           "internalTags": ["updated"]
@@ -216,8 +215,7 @@
           "eventUrl": null,
           "notes": "2026 finals completed June 26 at OSU-Cascades, Bend, OR. Monitor for 2027 cycle.",
           "prizeType": "cash",
-          "serves": "Oregon & SW Washington (collegiate)",
-          "internalTags": ["updated"]
+          "serves": "Oregon & SW Washington (collegiate)"
         }
       ]
     },
@@ -244,8 +242,7 @@
           "url": "https://www.otradi.org",
           "eventUrl": "https://www.otradi.org/events/",
           "notes": "OBI Annual Startup Spotlight Expo: September 17, 2026, 5:00–8:00 PM. Showcases biotech and life sciences startups. $75 admission. Register at otradi.org/events/.",
-          "prizeType": "cash",
-          "internalTags": ["updated"]
+          "prizeType": "cash"
         }
       ]
     },
@@ -296,13 +293,14 @@
       "events": [
         {
           "name": "Cascadia CleanTech Accelerator",
-          "status": "monitor",
+          "status": "inactive",
           "description": "18-week virtual accelerator for pre-seed cleantech startups in the Northwest. Includes mentorship, curriculum, and pitch-based funding competition. Program runs May–September annually.",
           "url": "https://cascadiacleantech.org/accelerate/",
-          "eventUrl": "https://cascadiacleantech.org/accelerate/apply/",
-          "notes": "Applications typically open in spring for May start. Monitor their site.",
+          "eventUrl": null,
+          "notes": "No active cycle found; website shows 2024 content only. Monitor for future announcements.",
           "prizeType": "both",
-          "accelerator": true
+          "accelerator": true,
+          "internalTags": ["updated"]
         }
       ]
     },
@@ -356,8 +354,7 @@
           "url": "https://www.founderslive.com/",
           "eventUrl": "https://www.founderslive.com/events-list",
           "notes": "Last event June 25, 2026 at White Owl Social Club, Portland. No upcoming Portland events currently listed. Monitor founderslive.com for next Portland date. Apply to pitch at founderslive.com/pitch.",
-          "prizeType": "in-kind",
-          "internalTags": ["updated"]
+          "prizeType": "in-kind"
         }
       ]
     },
@@ -381,10 +378,11 @@
           "name": "Founders Live Seattle",
           "status": "accepting",
           "description": "Monthly happy-hour pitch competition where 5 founders each give a 99-second pitch followed by audience Q&A. Audience votes determine the winner. Seattle is the birthplace of Founders Live.",
-          "url": "https://www.founderslive.com/events-list/seattle-2026-07",
+          "url": "https://www.founderslive.com/events-list/seattle-2026-08",
           "eventUrl": "https://www.founderslive.com/pitch",
-          "notes": "Next event July 30, 2026 in Seattle (location TBD). Apply to pitch at founderslive.com/pitch.",
-          "prizeType": "in-kind"
+          "notes": "Next event August 6, 2026 at Seattle Climate Innovation Hub (6–9 PM). Apply to pitch at founderslive.com/pitch.",
+          "prizeType": "in-kind",
+          "internalTags": ["updated"]
         }
       ]
     },
@@ -439,16 +437,15 @@
       "events": [
         {
           "name": "Beaverton Startup Challenge",
-          "status": "accepting",
+          "status": "monitor",
           "description": "Annual funding competition operated by the Oregon Startup Center in partnership with the City of Beaverton and the Westside Startup Fund. Open to scalable startups across tech, consumer products, manufacturing, bio/life sciences, and cleantech. Winners receive a SAFE note investment (historically ~$20k), 6 months of mentorship, and a Demo Day showcase.",
           "url": "https://www.oregonstartupcenter.org/beaverton-startup-challenge",
-          "eventUrl": "https://www.oregonstartupcenter.org/beaverton-startup-challenge",
-          "notes": "Applications now open for the 2026 Beaverton Startup Challenge. 2025 Demo Day completed May 13 at the Patricia Reser Center for the Arts. Applications typically open Q1 annually.",
+          "eventUrl": null,
+          "notes": "2025 Demo Day completed May 13 at the Patricia Reser Center for the Arts. Applications typically open Q1 annually. Monitor for 2027 cycle.",
           "prizeType": "investment",
           "counties": [
             "Washington County"
-          ],
-          "internalTags": ["updated"]
+          ]
         }
       ]
     },
@@ -476,8 +473,7 @@
           "url": "https://businessimpactnw.org/annual-events/impact-pitch/overview/",
           "eventUrl": "https://businessimpactnw.org/annual-events/impact-pitch/contest/#ipapplication",
           "notes": "Round 1 closed June 1. Round 2 closed June 30 (results July 15). Round 3 submissions due August 10; coach meetings July 20–24. Live pitch event October 1, 2026. $46,000 total in prizes.",
-          "prizeType": "cash",
-          "internalTags": ["updated"]
+          "prizeType": "cash"
         }
       ]
     },


### PR DESCRIPTION
=== Weekly Update Summary (2026-07-08) ===                                                                                                                                                                           
                                            
  CLEARED INTERNAL TAGS: 7 events had tags removed                                                                                                                                                                     
                                                                                                                                                                                                                       
  UPDATED LISTINGS (4):                                                                                                                                                                                                
    - TiE Oregon / TiE Women Global Pitch Competition: Corrected semi-final dates                                                                                                                                      
      and venue (NA/Europe Sept 17–18 in LA; Asia Sept 24–26 in Hyderabad; Grand                                                                                                                                       
      Finale confirmed Dec 14–15 in Indore, India)                                                                                                                                                                     
    - Founders Live Seattle: Next event moved to Aug 6 at Seattle Climate                                                                                                                                              
      Innovation Hub; updated 404'd event URL to /seattle-2026-08                                                                                                                                                      
    - Cascadia CleanTech Accelerator: Status monitor → inactive; eventUrl → null;                                                                                                                                      
      website shows only 2024 content                                                                                                                                                                                  
    - Beaverton Startup Challenge: Status accepting → monitor; eventUrl → null;                                                                                                                                        
      website banner is stale (no active 2026 cycle confirmed)                                                                                                                                                         
      [no "updated" badge per your instruction]                                                                                                                                                                        
                                                                                                                                                                                                                       
  NEW ENTRIES ADDED (0): None provided                                                                                                                                                                                 
                                                                                                                                                                                                                       
  NO CHANGES DETECTED:                                                                                                                                                                                                 
    17 other events checked, no material changes found.   