### PR TITLE
Weekly update.

### DIFF
--- a/data.json
+++ b/data.json
@@ -2,7 +2,7 @@
   "meta": {
     "siteName": "PitchMap PNW",
     "tagline": "The PNW startup pitch competition directory",
-    "lastUpdated": "2026-07-22",
+    "lastUpdated": "2026-07-29",
     "maintainer": "Leila Kaneda",
     "githubHandle": "lkaneda"
   },
@@ -29,7 +29,7 @@
           "description": "Portland's monthly pitch event reintroduced in 2024 by UpStart Collective. Founders get 3 minutes to pitch, audience votes for the winner. Monthly champion advances to an annual Championship Showdown.",
           "url": "https://www.pitchatdemolicious.com",
           "eventUrl": "https://forms.gle/TKvxFS2taT7NtRZb8",
-          "notes": "Actively accepting pitch applications for 2026. Next upcoming event: August 13 at UpStart Collective (Big Pink). Champion of Champions planned for December 2026 at Mission Theater. Sign up at their website.",
+          "notes": "Actively accepting pitch applications for 2026. Upcoming events: August 13 and September 17 at UpStart Collective (Big Pink). Champion of Champions planned for December 2026 at Mission Theater. Sign up at their website.",
           "internalTags": ["updated"],
           "prizeType": "none"
         }
@@ -140,7 +140,8 @@
           "description": "5-week capital and funding literacy program for early-stage consumer packaged goods founders (food, beverage, personal care, wellness, lifestyle, and pet products) in Oregon and SW Washington. Virtual curriculum covers funding strategies, valuations, cap tables, and due diligence, culminating in a live Pitch Day in front of investors and community partners.",
           "url": "https://www.oen.org/2026-angel-oregon-consumer-packaged-goods/",
           "eventUrl": "https://oen.app.neoncrm.com/np/clients/oen/event.jsp?event=520&",
-          "notes": "Cohort 1 Pitch Day completed April 8. Cohort 2 now accepting registrations: September 16 – October 21, 2026. Pitch Day is October 21. $150 OEN members / $200 non-members.",
+          "notes": "Cohort 1 Pitch Day completed April 8. Cohort 2 now accepting registrations: September 16 – October 21, 2026. Pitch Day is October 21. $150 OEN members / $200 non-members. Investment eligibility finalized and announced in June 2027.",
+          "internalTags": ["updated"],
           "prizeType": "investment",
           "accelerator": true
         },
@@ -271,8 +272,7 @@
           "eventUrl": null,
           "notes": "Program page (vertuelab.org/45-camp) returns 404 as of July 2026; homepage no longer lists 45Camp. Possible discontinuation. May remove listing if status remains inactive.",
           "prizeType": "investment",
-          "accelerator": true,
-          "internalTags": ["updated"]
+          "accelerator": true
         }
       ]
     },
@@ -306,8 +306,8 @@
     },
     {
       "id": "portland-startup-weekend",
-      "org": "Portland Startup Week",
-      "url": "https://www.portlandstartupweek.com/",
+      "org": "Oregon Startup Week",
+      "url": "https://oregonstartupweek.com/",
       "serviceArea": "portland-metro",
       "location": {
         "lat": 45.5231,
@@ -321,12 +321,13 @@
       ],
       "events": [
         {
-          "name": "Portland Startup Week",
+          "name": "Oregon Startup Week",
           "status": "monitor",
-          "description": "Week-long celebration of Portland's startup community including pitch events, workshops, and networking. Includes the annual Demolicious Startup Week edition.",
-          "url": "https://www.portlandstartupweek.com/",
+          "description": "Week-long celebration of the statewide startup community including pitch events, workshops, and networking. Includes the annual Demolicious Startup Week edition.",
+          "url": "https://oregonstartupweek.com/",
           "eventUrl": null,
-          "notes": "May 11–16, 2026 event completed (4,000+ attendees). Next: Portland Startup Week 2027, May 10–15, 2027.",
+          "notes": "Rebranded from Portland Startup Week to Oregon Startup Week; portlandstartupweek.com now redirects to oregonstartupweek.com. May 11–16, 2026 event completed (4,000+ attendees). Next: Oregon Startup Week 2027, May 10–15, 2027 at Big Pink, Portland. Submissions for events open the first week of November 2026.",
+          "internalTags": ["updated"],
           "prizeType": "cash"
         }
       ]
@@ -381,7 +382,6 @@
           "url": "https://www.founderslive.com/events-list/seattle-2026-08",
           "eventUrl": "https://www.founderslive.com/pitch",
           "notes": "Next event August 6, 2026 (venue TBA, 6–9 PM). Apply to pitch at founderslive.com/pitch.",
-          "internalTags": ["updated"],
           "prizeType": "in-kind"
         }
       ]

--- a/index.html
+++ b/index.html
@@ -1124,7 +1124,7 @@
     </div>
   </div>
   <div class="resource-banner">
-    <a href="https://lkaneda.github.io/ai-consumption-calc/" target="_blank" rel="noopener">This week's update consumed 💧 82.2 mL of water and ⚡ 15.75 Wh of energy</a>
+    <a href="https://lkaneda.github.io/ai-consumption-calc/" target="_blank" rel="noopener">This week's update consumed 💧 105.6 mL of water and ⚡ 20.25 Wh of energy</a>
   </div>
 </div>
 


### PR DESCRIPTION
⏺ === Weekly Update Summary (2026-07-29) ===

  CLEARED INTERNAL TAGS: 3 competitions had tags removed
    - Demolicious / UpStart Collective
    - VertueLab
    - Founders Live - Seattle

  UPDATED LISTINGS (3):
    - Demolicious / UpStart Collective: added September 17 UpStart Collective event alongside the existing August 13 date.
    - Oregon Entrepreneurs Network (OEN) — Angel Oregon CPG: added newly-published investment eligibility announcement date (June 2027), matching the info already tracked for the sibling Tech/BIO cohorts.
    - Portland Startup Week → renamed "Oregon Startup Week": site now redirects portlandstartupweek.com → oregonstartupweek.com; updated org name, url, event name/url, and notes to reflect the rebrand and note that event submissions
  open the first week of November 2026.

  NEW ENTRIES ADDED (0): None provided this week.

  NO CHANGES DETECTED:
    24 of 27 events checked, no material changes found (3 updated as listed above; SCORE Washington's 2 events could not be verified due to 403 errors).