### PR TITLE
Weekly update and fixed issue #89 for tie women pitch update.

### DIFF
--- a/data.json
+++ b/data.json
@@ -2,7 +2,7 @@
   "meta": {
     "siteName": "PitchMap PNW",
     "tagline": "The PNW startup pitch competition directory",
-    "lastUpdated": "2026-08-05",
+    "lastUpdated": "2026-08-12",
     "maintainer": "Leila Kaneda",
     "githubHandle": "lkaneda"
   },
@@ -78,9 +78,10 @@
           "description": "Global pitch competition dedicated to empowering women entrepreneurs. The PNW regional winner advances to compete globally for equity-free prize money. Open to female-founded or co-founded businesses (minimum 33% female equity) registered after January 1, 2019 and actively seeking funding.",
           "url": "https://www.tiewomen.org/",
           "eventUrl": "https://tiewomen.pitchday.pro/events-portfolio/1710",
-          "notes": "Application deadline was June 30, 2026 (now closed). Chapter Mentoring & Finals: June 26–Aug 31; Semi-finals NA/Europe: September 17–18 (TiE Los Angeles); Semi-finals Asia: September 24–26 (TiE Hyderabad); Grand Finale: December 14–15, 2026 at TiE Global Summit in Indore, India. Over $100,000 in equity-free prizes; top winner receives $50,000.",
+          "notes": "Application deadline was June 30, 2026 (now closed). TiE Oregon Regional Pitch Competition: August 12, 2026 (preceded by workshops July 22, 29, and August 5). Chapter Mentoring & Finals: June 26–Aug 31; Semi-finals NA/Europe: September 17–18 (TiE Los Angeles); Semi-finals Asia: September 24–26 (TiE Hyderabad); Grand Finale: December 14–15, 2026 at TiE Global Summit in Indore, India. Over $100,000 in equity-free prizes; top winner receives $50,000.",
           "prizeType": "cash",
-          "serves": "Pacific Northwest (with global competition)"
+          "serves": "Pacific Northwest (with global competition)",
+          "internalTags": ["updated"]
         },
         {
           "name": "TiE U Regional Pitch Competition",
@@ -118,10 +119,11 @@
           "name": "Pitch Please",
           "status": "accepting",
           "description": "Monthly pitch event where founders get 5 minutes to pitch virtually or in person. Regional thought leaders ask questions and give feedback.",
-          "url": "https://oen.app.neoncrm.com/np/clients/oen/event.jsp?event=546",
-          "eventUrl": "https://oen.app.neoncrm.com/np/clients/oen/event.jsp?event=546",
-          "notes": "Runs monthly. Check OEN calendar for next date.",
-          "prizeType": "none"
+          "url": "https://oen.app.neoncrm.com/nx/portal/event-detail?event=551",
+          "eventUrl": "https://oen.app.neoncrm.com/nx/portal/event-detail?event=551",
+          "notes": "Runs monthly. Next event: August 18, 2026. Check OEN calendar for future dates.",
+          "prizeType": "none",
+          "internalTags": ["updated"]
         },
         {
           "name": "Angel Oregon Technology",
@@ -379,7 +381,6 @@
           "url": "https://www.founderslive.com/events-list/seattle-2026-08",
           "eventUrl": "https://www.founderslive.com/pitch",
           "notes": "Next event September 24, 2026 (venue TBA, 6–9 PM). Apply to pitch at founderslive.com/pitch.",
-          "internalTags": ["updated"],
           "prizeType": "in-kind"
         }
       ]

--- a/index.html
+++ b/index.html
@@ -1124,7 +1124,7 @@
     </div>
   </div>
   <div class="resource-banner">
-    <a href="https://lkaneda.github.io/ai-consumption-calc/" target="_blank" rel="noopener">This week's update consumed 💧 81.4 mL of water and ⚡ 15.6 Wh of energy</a>
+    <a href="https://lkaneda.github.io/ai-consumption-calc/" target="_blank" rel="noopener">This week's update consumed 💧 112.8 mL of water and ⚡ 21.62 Wh of energy</a>
   </div>
 </div>
 


### PR DESCRIPTION
=== Weekly Update Summary (2026-08-12) ===

  CLEARED INTERNAL TAGS: 1 competition had tags removed (Founders Live - Seattle)

  UPDATED LISTINGS (2):
  - TiE Oregon: Added detail on the TiE Oregon Women Pitch Competition (Regional Pitch Competition, August 12, 2026, preceded by workshops July 22/29 and Aug 5) to the "TiE Women Global Pitch Competition" event notes, per
  [issue #89](https://github.com/lkaneda/pitchmap-pnw/issues/89).
  - Oregon Entrepreneurs Network (OEN): "Pitch Please" — added next event date (August 18, 2026) to notes, and replaced the stale url/eventUrl links with the current one
  (https://oen.app.neoncrm.com/nx/portal/event-detail?event=551).

  NEW ENTRIES ADDED (0):
    None — issue #89 was labeled listing-update, not listing-request.
